### PR TITLE
Multiple code cleanup for Sonar rules: squid:S00122, squid:S1118, squ…

### DIFF
--- a/library/src/main/java/com/pavelsikun/vintagechroma/ChromaDialog.java
+++ b/library/src/main/java/com/pavelsikun/vintagechroma/ChromaDialog.java
@@ -116,7 +116,9 @@ public class ChromaDialog extends DialogFragment {
         chromaView.enableButtonBar(new ChromaView.ButtonBarListener() {
             @Override
             public void onPositiveButtonClick(int color) {
-                if(listener != null) listener.onColorSelected(color);
+                if(listener != null) {
+                    listener.onColorSelected(color);
+                }
                 dismiss();
             }
 

--- a/library/src/main/java/com/pavelsikun/vintagechroma/ChromaDialogCompat.java
+++ b/library/src/main/java/com/pavelsikun/vintagechroma/ChromaDialogCompat.java
@@ -35,7 +35,9 @@ class ChromaDialogCompat {
         dialogView.enableButtonBar(new ChromaView.ButtonBarListener() {
             @Override
             public void onPositiveButtonClick(int color) {
-                if(listener != null) listener.onColorSelected(color);
+                if(listener != null) {
+                    listener.onColorSelected(color);
+                }
                 dialog.dismiss();
             }
 

--- a/library/src/main/java/com/pavelsikun/vintagechroma/ChromaUtil.java
+++ b/library/src/main/java/com/pavelsikun/vintagechroma/ChromaUtil.java
@@ -5,6 +5,9 @@ package com.pavelsikun.vintagechroma;
  */
 public class ChromaUtil {
 
+    private ChromaUtil() {
+    }
+
     public static String getFormattedColorString(int color, boolean showAlpha) {
         if(showAlpha) {
             return String.format("#%08X", color);

--- a/library/src/main/java/com/pavelsikun/vintagechroma/colormode/ColorMode.java
+++ b/library/src/main/java/com/pavelsikun/vintagechroma/colormode/ColorMode.java
@@ -16,8 +16,6 @@ public enum ColorMode {
 
     public AbstractColorMode getColorMode() {
         switch (this) {
-            case RGB:
-                return new RGB();
             case HSV:
                 return new HSV();
             case ARGB:
@@ -28,6 +26,7 @@ public enum ColorMode {
                 return new CMYK255();
             case HSL:
                 return new HSL();
+            case RGB:
             default:
                 return new RGB();
         }

--- a/library/src/main/java/com/pavelsikun/vintagechroma/colormode/mode/HSL.java
+++ b/library/src/main/java/com/pavelsikun/vintagechroma/colormode/mode/HSL.java
@@ -36,7 +36,9 @@ public class HSL implements AbstractColorMode {
         float c = hsl[2];
 
         b *= c < 0.5 ? c : 1 - c;
-        if(b == 0) b = 0.001f;
+        if(b == 0) {
+            b = 0.001f;
+        }
 
         return new float[] { a, 2 * b / (c + b), c + b };
     }

--- a/library/src/main/java/com/pavelsikun/vintagechroma/view/ChannelView.java
+++ b/library/src/main/java/com/pavelsikun/vintagechroma/view/ChannelView.java
@@ -60,7 +60,9 @@ public class ChannelView extends RelativeLayout {
             public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
                 channel.setProgress(progress);
                 setProgress(progressView, progress);
-                if(listener != null) listener.onProgressChanged();
+                if(listener != null) {
+                    listener.onProgressChanged();
+                }
             }
 
             @Override


### PR DESCRIPTION
This pull request is solving following Sonar rules:
**squid:S00122**- “Statements should be on separate lines”.
**squid:S1118** - “Utility classes should not have public constructors ”
**squid:UselessParenthesesCheck**: Useless parentheses around expressions should be removed to prevent any misunderstanding

You can find more information about the issues here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00122
https://dev.eclipse.org/sonar/rules/show/squid:S1118
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck

Please let me know if you have any questions.
Ayman Elkfrawy